### PR TITLE
Don't rely on `context.request.rawBody`

### DIFF
--- a/src/webhookValidator.ts
+++ b/src/webhookValidator.ts
@@ -66,7 +66,8 @@ export function webhookValidator({
         ? rawOriginalUrl.replace('%3F', '?')
         : rawOriginalUrl;
     const signature = context.get(TWILIO_SIGNATURE_HEADER_NAME);
-    const { body, rawBody } = context.request;
+    const { body } = context.request;
+    const rawBody = JSON.stringify(body);
     const hasBodyHash = originalUrl.includes('bodySHA256');
 
     const validSignature =


### PR DESCRIPTION
Some body parsing libraries for koa (like [`koa-better-body`](https://github.com/tunnckoCoreLabs/koa-better-body)) don't set the `rawBody` like [`koa-bodyparser`](https://github.com/koajs/bodyparser).
