### PR TITLE
Allow specifying a custom host to validate the request against

### DIFF
--- a/src/webhookValidator.ts
+++ b/src/webhookValidator.ts
@@ -1,6 +1,6 @@
 import * as url from 'url';
 
-import { Middleware, Context } from 'koa';
+import { Middleware } from 'koa';
 import {
   validateRequest,
   validateRequestWithBody
@@ -11,27 +11,26 @@ export const ERR_INVALID_REQUEST = 'Twilio request validation failed.';
 export const ERR_TOKEN_REQUIRED =
   'Twilio authToken is required for request validation.';
 
-function getUrlFromContext(context: Context): string {
-  return url.format({
-    protocol: context.protocol,
-    host: context.host,
-    pathname: context.originalUrl
-  });
-}
-
 export interface WebhookValidatorOptions {
+  host?: string;
   authToken?: string;
 }
 
 export function webhookValidator({
-  authToken = process.env.TWILIO_AUTH_TOKEN
+  authToken = process.env.TWILIO_AUTH_TOKEN,
+  host
 }: WebhookValidatorOptions = {}): Middleware {
   return async function hook(context, next) {
     if (!authToken) {
       return context.throw(500, ERR_TOKEN_REQUIRED);
     }
 
-    const rawOriginalUrl = getUrlFromContext(context);
+    const rawOriginalUrl = url.format({
+      protocol: context.protocol,
+      host: host || context.host,
+      pathname: context.originalUrl
+    });
+
     const originalUrl =
       context.originalUrl.search(/\?/) >= 0
         ? rawOriginalUrl.replace('%3F', '?')

--- a/test/webhookValidator.test.ts
+++ b/test/webhookValidator.test.ts
@@ -114,7 +114,26 @@ test('successfully resolves response with valid Twilio request signature', async
   server.close();
 });
 
-test('uses process.env.TWILIO_AUTH_TOKEN to resolve Twilio authToken', async () => {
+test('uses custom host to validate Twilio signature', async () => {
+  const host = 'api.acme.io';
+  const authToken = getMockAuthToken();
+  const server = await createTestService({ authToken, host });
+
+  const expectedSignature = getExpectedTwilioSignature(
+    authToken,
+    `http://${host}/twilio`,
+    {}
+  );
+
+  await request
+    .post(server.url)
+    .set(TWILIO_SIGNATURE_HEADER_NAME, expectedSignature)
+    .send()
+    .then(({ status }) => expect(status).toEqual(200));
+  server.close();
+});
+
+test('uses env variables to resolve Twilio authToken', async () => {
   process.env.TWILIO_AUTH_TOKEN = getMockAuthToken();
   const server = await createTestService();
 


### PR DESCRIPTION
If the canonical `process.env.HOST` variable is present, the computed Twilio request signature will be based on it rather than `context.host`. This is useful for people using something like a reverse proxy or AWS API Gateway to route their requests.