### PR TITLE
Add no signature header error, update error messages

### DIFF
--- a/test/webhookValidator.test.ts
+++ b/test/webhookValidator.test.ts
@@ -167,6 +167,17 @@ test('throws error with invalid Twilio request signature', async () => {
   server.close();
 });
 
+test('throws error with Twilio request without signature', async () => {
+  const authToken = getMockAuthToken();
+  const server = await createTestService({ authToken });
+  const [body] = getMockRequestBody();
+  await expect(request.post(server.url).send(body)).rejects.toThrowError(
+    'Bad Request'
+  );
+
+  server.close();
+});
+
 test('throws error with invalid bodySHA256', async () => {
   const authToken = getMockAuthToken();
   const server = await createTestService({ authToken });


### PR DESCRIPTION
Hi, thank you for the package.

This PR would make errors closer to errors in the official package.  

Changes:
1) Add "no signature header error"
Like here: https://github.com/twilio/twilio-node/blob/master/lib/webhooks/webhooks.js#L235

2) Make errors messages text like in the official package.  