### PR TITLE
Add custom protocol

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,13 @@ router.post(
 
 app.use(router.routes()).listen(3000);
 ```
+
+# Example usage with custom host and port (e.g. behind proxy)
+
+```typescript
+webhookValidator({
+  authToken: process.env.TWILIO_AUTH_TOKEN,
+  host: ctx.header['x-forwarded-host'],
+  protocol: ctx.header['x-forwarded-proto']
+});
+```

--- a/src/webhookValidator.ts
+++ b/src/webhookValidator.ts
@@ -15,11 +15,13 @@ export const ERR_SIGNATURE_REQUIRED =
 
 export interface WebhookValidatorOptions {
   host?: string;
+  protocol?: string;
   authToken?: string;
 }
 
 export function webhookValidator({
   authToken = process.env.TWILIO_AUTH_TOKEN,
+  protocol,
   host
 }: WebhookValidatorOptions = {}): Middleware {
   return async function hook(context, next) {
@@ -34,7 +36,7 @@ export function webhookValidator({
     }
 
     const rawOriginalUrl = url.format({
-      protocol: context.protocol,
+      protocol: protocol || context.protocol,
       host: host || context.host,
       pathname: context.originalUrl
     });

--- a/test/webhookValidator.test.ts
+++ b/test/webhookValidator.test.ts
@@ -52,7 +52,7 @@ async function createTestService(
   );
   app.use(router.routes());
 
-  const protocol = options ? options.protocol || 'http' : 'http';
+  const protocol = (options && options.protocol) || 'http';
 
   const server = http.createServer(app.callback());
   const host = `${protocol}://127.0.0.1`;


### PR DESCRIPTION
We are able to set custom host `webhookValidator({ host })`. 

It make sense also to have an option to set a protocol. E.g. when endpoint is behind a proxy (TLS termination proxy).

Example:
```
webhookValidator({
  host: ctx.header['x-forwarded-host'],
  protocol: ctx.header['x-forwarded-proto']
});
``` 

This PR would add an optional protocol.