### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ router.post(
 app.use(router.routes()).listen(3000);
 ```
 
-# Example usage with custom host and port (e.g. behind proxy)
+# Example usage with custom host and protocol (e.g. behind a proxy)
 
 ```typescript
 webhookValidator({


### PR DESCRIPTION
Sorry for that :) 

It is `protocol` not `port` in the documentation.

This PR would fix the `README.md`